### PR TITLE
Fix the request loop when over pipedrive API quota

### DIFF
--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -23,9 +23,6 @@ module Pipedrive
         res = connection.__send__(method.to_sym, url, params)
       rescue Errno::ETIMEDOUT
         retry
-      rescue Faraday::ParsingError
-        sleep 5
-        retry
       end
       process_response(res)
     end


### PR DESCRIPTION
Faraday will raise Faraday::ParsingError when Pipedrive returns 429 over limit, it will caused an endless request loop

Samples
https://us5.datadoghq.com/apm/resource/kami-api-worker/sidekiq.job/8aa512ca0f1f124d?query=env%3Aproduction%20operation_name%3Asidekiq.job%20service%3Akami-api-worker&env=production&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=1795174200825366339&timeHint=1700533218793&topGraphs=latency%3Alatency%2Chits%3Acount%2Cerrors%3Acount%2CbreakdownAs%3Apercentage&trace=AgAAAYvvra3paVRCXwAAAAAAAAAYAAAAAEFZdnZyYm5EQUFESmg5czNWOXBvTC04cgAAACQAAAAAMDE4YmVmYWQtZWI3YS00MTQ0LWI1NmUtMDFhZjkxN2VlZTUy&traceID=3165810967820393447&traces=qson%3A%28data%3A%28%29%2Cversion%3A%210%29&view=spans&start=1700520892138&end=1700535292138&paused=false