### PR TITLE
Add HTTP response status to response hash

### DIFF
--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -48,8 +48,13 @@ module Pipedrive
     end
 
     def failed_response(res)
-      failed_res = res.body.merge(success: false, not_authorized: false,
-                                  failed: false, headers: res.headers)
+      failed_res = res.body.merge(
+        success: false,
+        status: res.status,
+        not_authorized: false,
+        failed: false,
+        headers: res.headers
+      )
       case res.status
       when 401
         failed_res[:not_authorized] = true


### PR DESCRIPTION
The status would be really helpful when parsing errors.

Part of efforts for Pipedrive API problems: https://kamihq.slack.com/archives/C01UNVCGYD8/p1707938203048029