### PR TITLE
Varify the parameter id of find_by_id before pass it to make_api_call

### DIFF
--- a/lib/pipedrive/operations/read.rb
+++ b/lib/pipedrive/operations/read.rb
@@ -25,6 +25,8 @@ module Pipedrive
       end
 
       def find_by_id(id)
+        raise ArgumentError, "id must be Integer or String" unless id.is_a?(String) || id.is_a?(Integer)
+
         make_api_call(:get, id)
       end
     end

--- a/spec/lib/pipedrive/operations/read_spec.rb
+++ b/spec/lib/pipedrive/operations/read_spec.rb
@@ -10,9 +10,18 @@ RSpec.describe ::Pipedrive::Operations::Read do
   end
 
   describe '#find_by_id' do
-    it 'calls #make_api_call' do
+    it 'calls #make_api_call with an integer ID' do
       expect(subject).to receive(:make_api_call).with(:get, 12)
       subject.find_by_id(12)
+    end
+
+    it 'calls #make_api_call with a string ID' do
+      expect(subject).to receive(:make_api_call).with(:get, "12")
+      subject.find_by_id("12")
+    end
+
+    it 'raises when id is neither an integer nor a string' do
+      expect { subject.find_by_id({id: 12}) }.to raise_error(ArgumentError, "id must be Integer or String")
     end
   end
 


### PR DESCRIPTION
If we accidentally pass a hash to find_by_id method, it will make a request to index API. We actually expected it should raise an error in this case.