### PR TITLE
Fixes a specific issue on missing file error response

### DIFF
--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -48,7 +48,7 @@ module Pipedrive
     end
 
     def failed_response(res)
-      failed_res = res.body.merge(
+      failed_res = (res.body || {}).merge(
         success: false,
         status: res.status,
         not_authorized: false,


### PR DESCRIPTION
- some files cannot be found, instead of returning an error response Pipedrive redirects to File not found page
- redirect response has no body